### PR TITLE
Add chmod 777 option - Closes #12

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,21 @@ The application is delivered in multiple formats - a Docker image, a deb, and RP
 format for local building and implementation.
 
 The proxy handles two modes of operation - you can expose the HTTP server over a TCP port, or over Unix domain sockets.
-The latter is recommended for servers that will deploy this with the proxy running on the same machine as the SDK, preventing the need for network calls.
+The latter is recommended for servers that will deploy this with the proxy running on the same machine as the SDK,
+preventing the need for network calls.
 
-The HTTP server mode is a 1:1 replacement for the Bucketing API used by all SDKs in cloud bucketing mode, or can be used directly without an SDK as an API.
+The HTTP server mode is a 1:1 replacement for the Bucketing API used by all SDKs in cloud bucketing mode, or can be used
+directly without an SDK as an API.
 
 ### Docker
 
 The docker image published here is the base runtime version - expecting to be used as a base image for you to extend.
-The docker image expects that you use the environment variables to configure the proxy, but can be modified and extended to use a configuration
-file instead. 
+The docker image expects that you use the environment variables to configure the proxy, but can be modified and extended
+to use a configuration
+file instead.
 
-We also provide the raw application binary to wrap in your own daemon manager, or tie into your existing application lifecycle.
+We also provide the raw application binary to wrap in your own daemon manager, or tie into your existing application
+lifecycle.
 
 ## Options
 
@@ -29,6 +33,12 @@ Either a path to a config file which allows specifying multiple instances of a p
 used to configure the proxy.
 
 A simple healthcheck for each proxy instance can be performed by sending a GET request to the `/healthz` endpoint.
+
+Due to various deployment configurations - we recommend setting the file permissions for the resulting proxy file to be
+as restrictive as possible in your deployment scenario. However, to prevent issues with deployment, we provide the option
+to set the permissions to 777 via the `DVC_LB_PROXY_UNIX_SOCKET_777` environment variable, or the `unixSocket777` option
+in the config. This is not recommended for production deployments, but can be useful for testing locally, or whenever
+deployment configurations are not possible to set the permissions yourself later.
 
 ### Command Line Arguments
 
@@ -41,10 +51,11 @@ A simple healthcheck for each proxy instance can be performed by sending a GET r
 
 | KEY                                                    | TYPE          | DEFAULT | REQUIRED | DESCRIPTION                                                                     |
 |--------------------------------------------------------|---------------|---------|----------|---------------------------------------------------------------------------------|
-| DVC_LB_PROXY_CONFIG                                     | String        |         |          | The path to a JSON configuration file. |
+| DVC_LB_PROXY_CONFIG                                    | String        |         |          | The path to a JSON configuration file.                                          |
 | DVC_LB_PROXY_UNIX_SOCKET_PATH                          | String        |         |          | The path to the Unix socket.                                                    |
 | DVC_LB_PROXY_HTTP_PORT                                 | Integer       | 8080    |          | The port to listen on for HTTP requests. Defaults to 8080.                      |
 | DVC_LB_PROXY_UNIX_SOCKET_ENABLED                       | True or False | false   |          | Whether to enable the Unix socket. Defaults to false.                           |
+| DVC_LB_PROXY_UNIX_SOCKET_777                           | True or False | false   |          | Whether to set the Unix socket permissions to 777. Defaults to false.           |
 | DVC_LB_PROXY_HTTP_ENABLED                              | True or False | true    |          | Whether to enable the HTTP server. Defaults to true.                            |
 | DVC_LB_PROXY_SDK_KEY                                   | String        |         | true     | The Server SDK key to use for this instance.                                    |
 | DVC_LB_PROXY_PLATFORMDATA_SDKTYPE                      | String        |         |          |                                                                                 |

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ used to configure the proxy.
 
 A simple healthcheck for each proxy instance can be performed by sending a GET request to the `/healthz` endpoint.
 
-Due to various deployment configurations - we recommend setting the file permissions for the resulting proxy file to be
-as restrictive as possible in your deployment scenario. However, to prevent issues with deployment, we provide the
-option to set the permissions to your own custom mask via the `DVC_LB_PROXY_UNIX_SOCKET_PERMISSIONS` environment
-variable, or the `unixSocketPermissions` option in the config file. The default is `0755`.
+We recommend setting the file permissions for the unix socket to be as restrictive as possible. However, as a workaround
+for deployment issues, you can set the permissions to your own custom mask via the
+`DVC_LB_PROXY_UNIX_SOCKET_PERMISSIONS` environment variable, or the unixSocketPermissions option in the config file. The
+default is 0755
 
 ### Command Line Arguments
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,9 @@ used to configure the proxy.
 A simple healthcheck for each proxy instance can be performed by sending a GET request to the `/healthz` endpoint.
 
 Due to various deployment configurations - we recommend setting the file permissions for the resulting proxy file to be
-as restrictive as possible in your deployment scenario. However, to prevent issues with deployment, we provide the option
-to set the permissions to 777 via the `DVC_LB_PROXY_UNIX_SOCKET_777` environment variable, or the `unixSocket777` option
-in the config. This is not recommended for production deployments, but can be useful for testing locally, or whenever
-deployment configurations are not possible to set the permissions yourself later.
+as restrictive as possible in your deployment scenario. However, to prevent issues with deployment, we provide the
+option to set the permissions to your own custom mask via the `DVC_LB_PROXY_UNIX_SOCKET_PERMISSIONS` environment
+variable, or the `unixSocketPermissions` option in the config file. The default is `0755`.
 
 ### Command Line Arguments
 
@@ -55,7 +54,7 @@ deployment configurations are not possible to set the permissions yourself later
 | DVC_LB_PROXY_UNIX_SOCKET_PATH                          | String        |         |          | The path to the Unix socket.                                                    |
 | DVC_LB_PROXY_HTTP_PORT                                 | Integer       | 8080    |          | The port to listen on for HTTP requests. Defaults to 8080.                      |
 | DVC_LB_PROXY_UNIX_SOCKET_ENABLED                       | True or False | false   |          | Whether to enable the Unix socket. Defaults to false.                           |
-| DVC_LB_PROXY_UNIX_SOCKET_777                           | True or False | false   |          | Whether to set the Unix socket permissions to 777. Defaults to false.           |
+| DVC_LB_PROXY_UNIX_SOCKET_PERMISSIONS                   | String        | 0755    |          | The permissions to set on the Unix socket. Defaults to 0755                     |
 | DVC_LB_PROXY_HTTP_ENABLED                              | True or False | true    |          | Whether to enable the HTTP server. Defaults to true.                            |
 | DVC_LB_PROXY_SDK_KEY                                   | String        |         | true     | The Server SDK key to use for this instance.                                    |
 | DVC_LB_PROXY_PLATFORMDATA_SDKTYPE                      | String        |         |          |                                                                                 |

--- a/config.json.example
+++ b/config.json.example
@@ -6,6 +6,7 @@
       "unixSocketEnabled": false,
       "httpEnabled": true,
       "sdkKey": "dvc_YOUR_KEY_HERE",
+      "logFile": "/var/log/devcycle.log",
       "platformData": {
         "sdkType": "server",
         "sdkVersion": "2.10.2",

--- a/options.go
+++ b/options.go
@@ -22,15 +22,15 @@ type ProxyConfig struct {
 }
 
 type ProxyInstance struct {
-	UnixSocketPath    string                `json:"unixSocketPath" envconfig:"UNIX_SOCKET_PATH" desc:"The path to the Unix socket."`
-	HTTPPort          int                   `json:"httpPort" envconfig:"HTTP_PORT" default:"8080" desc:"The port to listen on for HTTP requests. Defaults to 8080."`
-	UnixSocketEnabled bool                  `json:"unixSocketEnabled" envconfig:"UNIX_SOCKET_ENABLED" default:"false" desc:"Whether to enable the Unix socket. Defaults to false."`
-	UnixSocket777     bool                  `json:"unixSocket777,omitempty" envconfig:"UNIX_SOCKET_777" default:"false" desc:"Whether to set the Unix socket permissions to 777. Defaults to false."`
-	HTTPEnabled       bool                  `json:"httpEnabled" envconfig:"HTTP_ENABLED" default:"true" desc:"Whether to enable the HTTP server. Defaults to true."`
-	SDKKey            string                `json:"sdkKey" required:"true" envconfig:"SDK_KEY" desc:"The Server SDK key to use for this instance."`
-	PlatformData      devcycle.PlatformData `json:"platformData" required:"true"`
-	SDKConfig         SDKConfig             `json:"sdkConfig" required:"true"`
-	dvcClient         *devcycle.Client
+	UnixSocketPath        string                `json:"unixSocketPath" envconfig:"UNIX_SOCKET_PATH" desc:"The path to the Unix socket."`
+	UnixSocketPermissions int                   `json:"unixSocketPermissions" envconfig:"UNIX_SOCKET_PERMISSIONS" default:"0755" desc:"The permissions to set on the Unix socket. Defaults to 0755"`
+	UnixSocketEnabled     bool                  `json:"unixSocketEnabled" envconfig:"UNIX_SOCKET_ENABLED" default:"false" desc:"Whether to enable the Unix socket. Defaults to false."`
+	HTTPPort              int                   `json:"httpPort" envconfig:"HTTP_PORT" default:"8080" desc:"The port to listen on for HTTP requests. Defaults to 8080."`
+	HTTPEnabled           bool                  `json:"httpEnabled" envconfig:"HTTP_ENABLED" default:"true" desc:"Whether to enable the HTTP server. Defaults to true."`
+	SDKKey                string                `json:"sdkKey" required:"true" envconfig:"SDK_KEY" desc:"The Server SDK key to use for this instance."`
+	PlatformData          devcycle.PlatformData `json:"platformData" required:"true"`
+	SDKConfig             SDKConfig             `json:"sdkConfig" required:"true"`
+	dvcClient             *devcycle.Client
 }
 
 type SDKConfig struct {
@@ -77,8 +77,13 @@ func (i *ProxyInstance) Default() {
 	if i.HTTPEnabled && i.HTTPPort == 0 {
 		i.HTTPPort = 8080
 	}
-	if i.UnixSocketEnabled && i.UnixSocketPath == "" {
-		i.UnixSocketPath = "/tmp/devcycle.sock"
+	if i.UnixSocketEnabled {
+		if i.UnixSocketPath == "" {
+			i.UnixSocketPath = "/tmp/devcycle.sock"
+		}
+		if i.UnixSocketPermissions == 0 {
+			i.UnixSocketPermissions = 0755
+		}
 	}
 }
 func (c *ProxyConfig) Default() {

--- a/options.go
+++ b/options.go
@@ -171,6 +171,7 @@ func ParseConfig(configPath string) (*ProxyConfig, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse config from JSON: %w", err)
 		}
+		proxyConfig.Default()
 	}
 
 	if !initialConfig.Debug {
@@ -188,11 +189,12 @@ func SampleProxyConfig() ProxyConfig {
 
 	proxyConfig := ProxyConfig{
 		Instances: []*ProxyInstance{{
-			UnixSocketPath:    "/tmp/devcycle.sock",
-			HTTPPort:          8080,
-			UnixSocketEnabled: false,
-			HTTPEnabled:       true,
-			SDKKey:            "",
+			UnixSocketPath:        "/tmp/devcycle.sock",
+			HTTPPort:              8080,
+			UnixSocketEnabled:     false,
+			UnixSocketPermissions: 755,
+			HTTPEnabled:           true,
+			SDKKey:                "",
 			PlatformData: devcycle.PlatformData{
 				SdkType:         "server",
 				SdkVersion:      devcycle.VERSION,

--- a/options.go
+++ b/options.go
@@ -23,7 +23,7 @@ type ProxyConfig struct {
 
 type ProxyInstance struct {
 	UnixSocketPath        string                `json:"unixSocketPath" envconfig:"UNIX_SOCKET_PATH" desc:"The path to the Unix socket."`
-	UnixSocketPermissions int                   `json:"unixSocketPermissions" envconfig:"UNIX_SOCKET_PERMISSIONS" default:"0755" desc:"The permissions to set on the Unix socket. Defaults to 0755"`
+	UnixSocketPermissions int                   `json:"unixSocketPermissions" envconfig:"UNIX_SOCKET_PERMISSIONS" default:"755" desc:"The permissions to set on the Unix socket. Defaults to 0755"`
 	UnixSocketEnabled     bool                  `json:"unixSocketEnabled" envconfig:"UNIX_SOCKET_ENABLED" default:"false" desc:"Whether to enable the Unix socket. Defaults to false."`
 	HTTPPort              int                   `json:"httpPort" envconfig:"HTTP_PORT" default:"8080" desc:"The port to listen on for HTTP requests. Defaults to 8080."`
 	HTTPEnabled           bool                  `json:"httpEnabled" envconfig:"HTTP_ENABLED" default:"true" desc:"Whether to enable the HTTP server. Defaults to true."`
@@ -82,7 +82,7 @@ func (i *ProxyInstance) Default() {
 			i.UnixSocketPath = "/tmp/devcycle.sock"
 		}
 		if i.UnixSocketPermissions == 0 {
-			i.UnixSocketPermissions = 0755
+			i.UnixSocketPermissions = 755
 		}
 	}
 }

--- a/options.go
+++ b/options.go
@@ -25,6 +25,7 @@ type ProxyInstance struct {
 	UnixSocketPath    string                `json:"unixSocketPath" envconfig:"UNIX_SOCKET_PATH" desc:"The path to the Unix socket."`
 	HTTPPort          int                   `json:"httpPort" envconfig:"HTTP_PORT" default:"8080" desc:"The port to listen on for HTTP requests. Defaults to 8080."`
 	UnixSocketEnabled bool                  `json:"unixSocketEnabled" envconfig:"UNIX_SOCKET_ENABLED" default:"false" desc:"Whether to enable the Unix socket. Defaults to false."`
+	UnixSocket777     bool                  `json:"unixSocket777,omitempty" envconfig:"UNIX_SOCKET_777" default:"false" desc:"Whether to set the Unix socket permissions to 777. Defaults to false."`
 	HTTPEnabled       bool                  `json:"httpEnabled" envconfig:"HTTP_ENABLED" default:"true" desc:"Whether to enable the HTTP server. Defaults to true."`
 	SDKKey            string                `json:"sdkKey" required:"true" envconfig:"SDK_KEY" desc:"The Server SDK key to use for this instance."`
 	PlatformData      devcycle.PlatformData `json:"platformData" required:"true"`

--- a/options.go
+++ b/options.go
@@ -28,6 +28,7 @@ type ProxyInstance struct {
 	HTTPPort              int                   `json:"httpPort" envconfig:"HTTP_PORT" default:"8080" desc:"The port to listen on for HTTP requests. Defaults to 8080."`
 	HTTPEnabled           bool                  `json:"httpEnabled" envconfig:"HTTP_ENABLED" default:"true" desc:"Whether to enable the HTTP server. Defaults to true."`
 	SDKKey                string                `json:"sdkKey" required:"true" envconfig:"SDK_KEY" desc:"The Server SDK key to use for this instance."`
+	LogFile               string                `json:"logFile" default:"/var/log/devcycle.log" envconfig:"LOG_FILE" desc:"The path to the log file. Defaults to /var/log/devcycle.log"`
 	PlatformData          devcycle.PlatformData `json:"platformData" required:"true"`
 	SDKConfig             SDKConfig             `json:"sdkConfig" required:"true"`
 	dvcClient             *devcycle.Client
@@ -76,6 +77,9 @@ func (i *ProxyInstance) Default() {
 	i.SDKConfig.Default()
 	if i.HTTPEnabled && i.HTTPPort == 0 {
 		i.HTTPPort = 8080
+	}
+	if i.LogFile == "" {
+		i.LogFile = "/var/log/devcycle.log"
 	}
 	if i.UnixSocketEnabled {
 		if i.UnixSocketPath == "" {

--- a/options_test.go
+++ b/options_test.go
@@ -33,13 +33,14 @@ func TestParseConfig(t *testing.T) {
 			expected: &ProxyConfig{
 				Instances: []*ProxyInstance{
 					{
-						UnixSocketPath:    "",
-						HTTPPort:          8080,
-						UnixSocketEnabled: false,
-						HTTPEnabled:       true,
-						SDKKey:            "dvc-test-key",
-						PlatformData:      api.PlatformData{},
-						SDKConfig:         SDKConfig{},
+						UnixSocketPath:        "",
+						UnixSocketPermissions: 755,
+						HTTPPort:              8080,
+						UnixSocketEnabled:     false,
+						HTTPEnabled:           true,
+						SDKKey:                "dvc-test-key",
+						PlatformData:          api.PlatformData{},
+						SDKConfig:             SDKConfig{},
 					},
 				},
 			},
@@ -72,11 +73,12 @@ func TestParseConfig(t *testing.T) {
 			expected: &ProxyConfig{
 				Instances: []*ProxyInstance{
 					{
-						UnixSocketPath:    "/tmp/dvc2.sock",
-						HTTPPort:          1234,
-						UnixSocketEnabled: true,
-						HTTPEnabled:       false,
-						SDKKey:            "dvc-test-key",
+						UnixSocketPath:        "/tmp/dvc2.sock",
+						HTTPPort:              1234,
+						UnixSocketEnabled:     true,
+						UnixSocketPermissions: 755,
+						HTTPEnabled:           false,
+						SDKKey:                "dvc-test-key",
 						PlatformData: api.PlatformData{
 							SdkType:         "sdk type",
 							SdkVersion:      "v1.2.3",

--- a/options_test.go
+++ b/options_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestParseConfig(t *testing.T) {
+	defaultSDKConfig := SDKConfig{}
+	defaultSDKConfig.Default()
 	tests := []struct {
 		name        string
 		flag        string
@@ -39,6 +41,7 @@ func TestParseConfig(t *testing.T) {
 						UnixSocketEnabled:     false,
 						HTTPEnabled:           true,
 						SDKKey:                "dvc-test-key",
+						LogFile:               "/var/log/devcycle.log",
 						PlatformData:          api.PlatformData{},
 						SDKConfig:             SDKConfig{},
 					},
@@ -79,6 +82,7 @@ func TestParseConfig(t *testing.T) {
 						UnixSocketPermissions: 755,
 						HTTPEnabled:           false,
 						SDKKey:                "dvc-test-key",
+						LogFile:               "/var/log/devcycle.log",
 						PlatformData: api.PlatformData{
 							SdkType:         "sdk type",
 							SdkVersion:      "v1.2.3",
@@ -120,8 +124,9 @@ func TestParseConfig(t *testing.T) {
 						UnixSocketEnabled: false,
 						HTTPEnabled:       false,
 						SDKKey:            "dvc-sample-key",
+						LogFile:           "/var/log/devcycle.log",
 						PlatformData:      api.PlatformData{},
-						SDKConfig:         SDKConfig{},
+						SDKConfig:         defaultSDKConfig,
 					},
 				},
 			},
@@ -139,8 +144,9 @@ func TestParseConfig(t *testing.T) {
 						UnixSocketEnabled: false,
 						HTTPEnabled:       false,
 						SDKKey:            "dvc-sample-key",
+						LogFile:           "/var/log/devcycle.log",
 						PlatformData:      api.PlatformData{},
-						SDKConfig:         SDKConfig{},
+						SDKConfig:         defaultSDKConfig,
 					},
 				},
 			},
@@ -157,6 +163,8 @@ func TestParseConfig(t *testing.T) {
 						UnixSocketEnabled: false,
 						HTTPEnabled:       true,
 						SDKKey:            "dvc_YOUR_KEY_HERE",
+						LogFile:           "/var/log/devcycle.log",
+
 						PlatformData: api.PlatformData{
 							SdkType:         "server",
 							SdkVersion:      "2.10.2",

--- a/proxy.go
+++ b/proxy.go
@@ -58,10 +58,9 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 			if err != nil {
 				log.Printf("Error running Unix socket server: %s", err)
 			}
-			if instance.UnixSocket777 {
-				if err = os.Chmod(instance.UnixSocketPath, 0777); err != nil {
-					log.Printf("Error setting Unix socket permissions: %s", err)
-				}
+			fileMode := os.FileMode(instance.UnixSocketPermissions)
+			if err = os.Chmod(instance.UnixSocketPath, fileMode); err != nil {
+				log.Printf("Error setting Unix socket permissions: %s", err)
 			}
 		}()
 		log.Printf("Running on unix socket: %s", instance.UnixSocketPath)

--- a/proxy.go
+++ b/proxy.go
@@ -2,6 +2,7 @@ package local_bucketing_proxy
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -12,6 +13,16 @@ import (
 )
 
 func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) {
+	gin.DisableConsoleColor()
+	logFile, err := os.OpenFile(instance.LogFile, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
+	if err != nil {
+		_ = fmt.Errorf("error opening log file: %s", err)
+		return nil, err
+	}
+	mw := io.MultiWriter(os.Stdout, logFile)
+	log.SetOutput(mw)
+	gin.DefaultWriter = mw
+
 	options := instance.BuildDevCycleOptions()
 	client, err := devcycle.NewClient(instance.SDKKey, options)
 	instance.dvcClient = client

--- a/proxy.go
+++ b/proxy.go
@@ -52,6 +52,7 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 		if _, err = os.Stat(instance.UnixSocketPath); err == nil {
 			return nil, fmt.Errorf("unix socket path %s already exists. Skipping instance creation", instance.UnixSocketPath)
 		}
+		err = nil
 		go func() {
 			err = r.RunUnix(instance.UnixSocketPath)
 			if err != nil {
@@ -65,5 +66,5 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 		}()
 		log.Printf("Running on unix socket: %s", instance.UnixSocketPath)
 	}
-	return instance, nil
+	return instance, err
 }

--- a/proxy.go
+++ b/proxy.go
@@ -65,5 +65,5 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 		}()
 		log.Printf("Running on unix socket: %s", instance.UnixSocketPath)
 	}
-	return instance, err
+	return instance, nil
 }

--- a/proxy.go
+++ b/proxy.go
@@ -41,7 +41,7 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 			return nil, fmt.Errorf("HTTP port must be set")
 		}
 		go func() {
-			err := r.Run(":" + strconv.Itoa(instance.HTTPPort))
+			err = r.Run(":" + strconv.Itoa(instance.HTTPPort))
 			if err != nil {
 				log.Printf("Error running HTTP server: %s", err)
 			}
@@ -49,13 +49,18 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 		log.Printf("HTTP server started on port %d", instance.HTTPPort)
 	}
 	if instance.UnixSocketEnabled {
-		if _, err := os.Stat(instance.UnixSocketPath); err == nil {
+		if _, err = os.Stat(instance.UnixSocketPath); err == nil {
 			return nil, fmt.Errorf("unix socket path %s already exists. Skipping instance creation", instance.UnixSocketPath)
 		}
 		go func() {
-			err := r.RunUnix(instance.UnixSocketPath)
+			err = r.RunUnix(instance.UnixSocketPath)
 			if err != nil {
 				log.Printf("Error running Unix socket server: %s", err)
+			}
+			if instance.UnixSocket777 {
+				if err = os.Chmod(instance.UnixSocketPath, 0777); err != nil {
+					log.Printf("Error setting Unix socket permissions: %s", err)
+				}
 			}
 		}()
 		log.Printf("Running on unix socket: %s", instance.UnixSocketPath)

--- a/proxy.go
+++ b/proxy.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	devcycle "github.com/devcyclehq/go-server-sdk/v2"
 	"github.com/gin-gonic/gin"
@@ -58,12 +59,16 @@ func NewBucketingProxyInstance(instance *ProxyInstance) (*ProxyInstance, error) 
 			if err != nil {
 				log.Printf("Error running Unix socket server: %s", err)
 			}
-			fileMode := os.FileMode(instance.UnixSocketPermissions)
-			if err = os.Chmod(instance.UnixSocketPath, fileMode); err != nil {
-				log.Printf("Error setting Unix socket permissions: %s", err)
-			}
 		}()
-		log.Printf("Running on unix socket: %s", instance.UnixSocketPath)
+		fileMode := os.FileMode(instance.UnixSocketPermissions)
+		_, err = os.Stat(instance.UnixSocketPath)
+		for ; err != nil; _, err = os.Stat(instance.UnixSocketPath) {
+			time.Sleep(1 * time.Second)
+		}
+		if err = os.Chmod(instance.UnixSocketPath, fileMode); err != nil {
+			log.Printf("Error setting Unix socket permissions: %s", err)
+		}
+		log.Printf("Running on unix socket: %s with file permissions %d", instance.UnixSocketPath, instance.UnixSocketPermissions)
 	}
 	return instance, err
 }


### PR DESCRIPTION
The Unix socket proxy needs to be world write/read/exec permissioned in a few deployment scenarios - but given this isn't a great solution - i'll leave it disabled as default.
