### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Test
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/DevCycleHQ/sdk-proxy/security/code-scanning/1](https://github.com/DevCycleHQ/sdk-proxy/security/code-scanning/1)

The best way to fix the problem is to introduce an explicit `permissions` block at the workflow or job level in `.github/workflows/test.yml`. Since both jobs (`test` and `docker`) only require access to the repository code (for checkout and build) and do not need to modify repository contents, issues, or pull requests, we should set `permissions: contents: read` either globally for the workflow or for each job individually. The recommended approach is to add the `permissions` block at the workflow root, right after the `name` key and before the `on` key, so that both jobs inherit the least-privilege setting unless they require something more. No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
